### PR TITLE
Adding batch script to archive raindrop bookmark URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,22 @@ Useful python scripts for administrative functions.
 
 ## Script Index
 
-## extract-raindrop-bookmarks.py
+### extract-raindrop-bookmarks.py
 
 This script uses the [Raindrop API](https://raindrop.io/dev/docs) to retrieve all the bookmark data for a particular collection.
 By default, the bookmarks from the [Presterity collection](https://raindrop.io/app/#/collection/2021037) are extracted. The retrieved data is written as JSON to 
 stdout or to a file along with metadata about the extract itself. Run with -h for usage.
 
+### archive-links.py
+
+This script uses the [Wayback Machine](https://archive.org/web/) to archive all of the bookmarks from a particular raindrop collection. By default, the bookmarks from the [Presterity collection](https://raindrop.io/app/#/collection/2021037) are archived. The archived URLs are written as JSON to stdout or to a file. Run with -h for usage.
+
+## Module Index
+
+### raindrop_api.py
+
+General-purpose API for retrieving bookmarks from the [Raindrop API](https://raindrop.io/dev/docs)
+
+### wayback_api.py
+
+General-purpose API for accessing the [Wayback Machine](https://archive.org/web/)

--- a/archive-links.py
+++ b/archive-links.py
@@ -1,0 +1,35 @@
+"""
+Script to ensure that all bookmarks from raindrop have been archived in the Way Back Machine (https://archive.org/web/)
+"""
+from typing import List, Callable, Tuple
+import json
+import sys
+from raindrop_api import extract_bookmarks
+from wayback_api import archive_url
+
+PRESTERITY_COLLECTION_ID = 2021037
+# undocumented API scraped from the 'save page' form here: https://archive.org/web/
+SAVE_PAGE_API  = 'http://web.archive.org/save/{url}'
+# see: https://archive.org/help/wayback_api.php
+CHECK_PAGE_API = 'http://archive.org/wayback/available'
+
+def archive_urls(urls: List[str], cb: Callable[[dict], None]) -> None:
+	"""
+	Batch archive a list of URLs
+
+	:param urls: list of URLs to archive
+	:param cb: a callback that is executed each time a URL is successfully archived. The callback is given the argument: {original: <url>, archive: <url>}
+	"""
+	for url in urls:
+		if "?" in url:
+			print("skipping url ", url)
+		else:
+			data = {'original': url, 'archive': archive_url(url)}
+			cb(data)
+
+if __name__ == '__main__':
+	raindrop_collection = extract_bookmarks(PRESTERITY_COLLECTION_ID)
+	bookmarks = raindrop_collection.get('items', [])
+	f = lambda x: x.get('link', '')
+	urls = list(map(f, bookmarks))
+	archive_urls(urls, lambda x: print(json.dumps(x)))

--- a/archive-links.py
+++ b/archive-links.py
@@ -9,59 +9,60 @@ from raindrop_api import extract_bookmarks
 from wayback_api import check_and_archive_url
 import logging
 
+log = logging.getLogger(__name__)
+
 DEFAUlT_PAGE_SIZE = 40
 PRESTERITY_COLLECTION_ID = 2021037
 
 def build_parser() -> argparse.ArgumentParser:
-	"""Construct argument parser for script.
+    """Construct argument parser for script.
 
-	:return: ArgumentParser
-	"""
-	parser = argparse.ArgumentParser(description=__doc__)
-	help_msg = 'id of Raindrop collection of interest; default is {0} (Presterity)'.format(
-	    PRESTERITY_COLLECTION_ID)
-	parser.add_argument('--collection', '-c', type=int, default=PRESTERITY_COLLECTION_ID, 
-	                    help=help_msg)
-	help_msg = 'number of requested bookmarks per query; default is {0} (max allowed)'.format(
-	    DEFAUlT_PAGE_SIZE)
-	parser.add_argument('--page-size', '-s', type=int, default=DEFAUlT_PAGE_SIZE, help=help_msg)
-	parser.add_argument('--outfile', '-o', help='file for results; default is stdout')
-	parser.add_argument('--verbose', '-v', action='store_true', help='log level DEBUG')
-	return parser
+    :return: ArgumentParser
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    help_msg = 'id of Raindrop collection of interest; default is {0} (Presterity)'.format(
+        PRESTERITY_COLLECTION_ID)
+    parser.add_argument('--collection', '-c', type=int, default=PRESTERITY_COLLECTION_ID, 
+                        help=help_msg)
+    help_msg = 'number of requested bookmarks per query; default is {0} (max allowed)'.format(
+        DEFAUlT_PAGE_SIZE)
+    parser.add_argument('--page-size', '-s', type=int, default=DEFAUlT_PAGE_SIZE, help=help_msg)
+    parser.add_argument('--outfile', '-o', help='file for results; default is stdout')
+    parser.add_argument('--verbose', '-v', action='store_true', help='log level DEBUG')
+    return parser
 
 
-def archive_urls(urls: List[str], log, cb: Callable[[dict], None]) -> None:
-	"""
-	Batch archive a list of URLs
+def archive_urls(urls: List[str], cb: Callable[[dict], None]) -> None:
+    """
+    Batch archive a list of URLs
 
-	:param urls: list of URLs to archive
-	:param cb: a callback that is executed each time a URL is successfully archived. 
-	The callback is given the argument: {original: <url>, archive: <url>}
-	"""
-	for url in urls:
-		archived = check_and_archive_url(url)
-		if archived is None:
-			log.warn("unable to archive url %s", url)
-			data = {'original': url}
-		else:
-			data = {'original': url, 'archive': archived}
-		cb(data)
+    :param urls: list of URLs to archive
+    :param cb: a callback that is executed each time a URL is successfully archived. 
+    The callback is given the argument: {original: <url>, archive: <url>}
+    """
+    for url in urls:
+        archived = check_and_archive_url(url)
+        if archived is None:
+            log.warn("unable to archive url %s", url)
+            data = {'original': url}
+        else:
+            data = {'original': url, 'archive': archived}
+        cb(data)
 
 if __name__ == '__main__':
-	args = build_parser().parse_args()
-	logging.basicConfig(level=logging.WARN)
-	log = logging.getLogger(__name__)
-	if args.verbose:
-		log.setLevel(logging.DEBUG)
-	else:
-		log.setLevel(logging.INFO)
+    args = build_parser().parse_args()
+    logging.basicConfig(level=logging.WARN)
+    if args.verbose:
+        log.setLevel(logging.DEBUG)
+    else:
+        log.setLevel(logging.INFO)
 
-	raindrop_collection = extract_bookmarks(args.collection, args.page_size, log)
-	bookmarks = raindrop_collection.get('items', [])
-	urls = list(map(lambda x: x.get('link', ''), bookmarks))
+    raindrop_collection = extract_bookmarks(args.collection, args.page_size)
+    bookmarks = raindrop_collection.get('items', [])
+    urls = list(map(lambda x: x.get('link', ''), bookmarks))
 
-	# Redirect stdout to outfile, if specified
-	if args.outfile:
-		sys.stdout = open(args.outfile, 'w')
+    # Redirect stdout to outfile, if specified
+    if args.outfile:
+        sys.stdout = open(args.outfile, 'w')
 
-	archive_urls(urls, log, lambda x: sys.stdout.write((json.dumps(x) + '\n')))
+    archive_urls(urls, lambda x: sys.stdout.write((json.dumps(x) + '\n')))

--- a/archive-links.py
+++ b/archive-links.py
@@ -1,35 +1,67 @@
 """
 Script to ensure that all bookmarks from raindrop have been archived in the Way Back Machine (https://archive.org/web/)
 """
+import argparse
 from typing import List, Callable, Tuple
 import json
 import sys
 from raindrop_api import extract_bookmarks
-from wayback_api import archive_url
+from wayback_api import check_and_archive_url
+import logging
 
+DEFAUlT_PAGE_SIZE = 40
 PRESTERITY_COLLECTION_ID = 2021037
-# undocumented API scraped from the 'save page' form here: https://archive.org/web/
-SAVE_PAGE_API  = 'http://web.archive.org/save/{url}'
-# see: https://archive.org/help/wayback_api.php
-CHECK_PAGE_API = 'http://archive.org/wayback/available'
 
-def archive_urls(urls: List[str], cb: Callable[[dict], None]) -> None:
+def build_parser() -> argparse.ArgumentParser:
+	"""Construct argument parser for script.
+
+	:return: ArgumentParser
+	"""
+	parser = argparse.ArgumentParser(description=__doc__)
+	help_msg = 'id of Raindrop collection of interest; default is {0} (Presterity)'.format(
+	    PRESTERITY_COLLECTION_ID)
+	parser.add_argument('--collection', '-c', type=int, default=PRESTERITY_COLLECTION_ID, 
+	                    help=help_msg)
+	help_msg = 'number of requested bookmarks per query; default is {0} (max allowed)'.format(
+	    DEFAUlT_PAGE_SIZE)
+	parser.add_argument('--page-size', '-s', type=int, default=DEFAUlT_PAGE_SIZE, help=help_msg)
+	parser.add_argument('--outfile', '-o', help='file for results; default is stdout')
+	parser.add_argument('--verbose', '-v', action='store_true', help='log level DEBUG')
+	return parser
+
+
+def archive_urls(urls: List[str], log, cb: Callable[[dict], None]) -> None:
 	"""
 	Batch archive a list of URLs
 
 	:param urls: list of URLs to archive
-	:param cb: a callback that is executed each time a URL is successfully archived. The callback is given the argument: {original: <url>, archive: <url>}
+	:param cb: a callback that is executed each time a URL is successfully archived. 
+	The callback is given the argument: {original: <url>, archive: <url>}
 	"""
 	for url in urls:
-		if "?" in url:
-			print("skipping url ", url)
+		archived = check_and_archive_url(url)
+		if archived is None:
+			log.warn("unable to archive url %s", url)
+			data = {'original': url}
 		else:
-			data = {'original': url, 'archive': archive_url(url)}
-			cb(data)
+			data = {'original': url, 'archive': archived}
+		cb(data)
 
 if __name__ == '__main__':
-	raindrop_collection = extract_bookmarks(PRESTERITY_COLLECTION_ID)
+	args = build_parser().parse_args()
+	logging.basicConfig(level=logging.WARN)
+	log = logging.getLogger(__name__)
+	if args.verbose:
+		log.setLevel(logging.DEBUG)
+	else:
+		log.setLevel(logging.INFO)
+
+	raindrop_collection = extract_bookmarks(args.collection, args.page_size, log)
 	bookmarks = raindrop_collection.get('items', [])
-	f = lambda x: x.get('link', '')
-	urls = list(map(f, bookmarks))
-	archive_urls(urls, lambda x: print(json.dumps(x)))
+	urls = list(map(lambda x: x.get('link', ''), bookmarks))
+
+	# Redirect stdout to outfile, if specified
+	if args.outfile:
+		sys.stdout = open(args.outfile, 'w')
+
+	archive_urls(urls, log, lambda x: sys.stdout.write((json.dumps(x) + '\n')))

--- a/extract-raindrop-bookmarks.py
+++ b/extract-raindrop-bookmarks.py
@@ -8,6 +8,7 @@ import json
 import logging
 import sys
 from typing import List, Tuple
+from raindrop_api import extract_bookmarks
 
 import requests
 
@@ -17,50 +18,54 @@ RAINDROP_BOOKMARK_API = 'https://raindrop.io/api/raindrops/{collection_id}'
 PAGE_SIZE = 40  # max number of results per page 
 PRESTERITY_COLLECTION_ID = 2021037
 
-
-def extract_bookmarks(collection_id: int) -> None:
-    """Retrieve all bookmarks in specified collection; write results as JSON to stdout.
-
-    For documentation on bookmark JSON: https://raindrop.io/dev/docs#bookmarks
-    
-    :param collection_id: int that is Raindrop collection id
-    """
-    page_number = 0
-    bookmarks, collection_size = get_bookmarks_on_page(collection_id, page_number=page_number)
-    bookmarks_retrieved = len(bookmarks)
-    collection_data = {'collection_id': collection_id,
-                       'request_date': datetime.utcnow().isoformat(),
-                       'length': collection_size,
-                       'items': bookmarks}
-
-    while bookmarks_retrieved < collection_size:
-        page_number += 1
-        bookmarks, new_size = get_bookmarks_on_page(collection_id, page_number=page_number)
-        if new_size != collection_size:
-            raise ValueError("Collection changed size during extract; please re-run")
-        bookmarks_retrieved += len(bookmarks)
-        collection_data['items'].extend(bookmarks)
-
+def write_bookmarks(collection_id: int) -> None:
+    collection_data = extract_bookmarks(collection_id, log)
     # Serialize data and write to stdout
-    sys.stdout.write(json.dumps(collection_data))
+    sys.stdout.write(json.dumps(collection_data, indent = 4))
+
+
+# def extract_bookmarks(collection_id: int) -> dict:
+#     """Retrieve all bookmarks in specified collection; write results as JSON to stdout.
+
+#     For documentation on bookmark JSON: https://raindrop.io/dev/docs#bookmarks
+    
+#     :param collection_id: int that is Raindrop collection id
+#     """
+#     page_number = 0
+#     bookmarks, collection_size = get_bookmarks_on_page(collection_id, page_number=page_number)
+#     bookmarks_retrieved = len(bookmarks)
+#     collection_data = {'collection_id': collection_id,
+#                        'request_date': datetime.utcnow().isoformat(),
+#                        'length': collection_size,
+#                        'items': bookmarks}
+
+#     while bookmarks_retrieved < collection_size:
+#         page_number += 1
+#         bookmarks, new_size = get_bookmarks_on_page(collection_id, page_number=page_number)
+#         if new_size != collection_size:
+#             raise ValueError("Collection changed size during extract; please re-run")
+#         bookmarks_retrieved += len(bookmarks)
+#         collection_data['items'].extend(bookmarks)
+
+#     return collection_data
     
 
-def get_bookmarks_on_page(collection_id: int, page_number: int=0 ) -> Tuple[List[dict], int]:
-    """Retrieve collection bookmarks for specified page number.
+# def get_bookmarks_on_page(collection_id: int, page_number: int=0 ) -> Tuple[List[dict], int]:
+#     """Retrieve collection bookmarks for specified page number.
 
-    :param collection_id: int that is Raindrop collection id
-    :param page_number: optional int that is page number; default is 0
+#     :param collection_id: int that is Raindrop collection id
+#     :param page_number: optional int that is page number; default is 0
 
-    :return: list of JSON objects that are Raindrop bookmarks
-    """
-    uri = RAINDROP_BOOKMARK_API.format(collection_id=collection_id)
-    query_params = {'page': page_number, 'perpage': PAGE_SIZE}
-    log.debug("Making request to %s", uri)
-    response_data = requests.get(uri, params=query_params).json()
-    items = response_data.get('items', [])
-    total_item_count = response_data.get('count')
-    log.debug("Retrieved %d of %d bookmarks", len(items), total_item_count)
-    return items, total_item_count
+#     :return: list of JSON objects that are Raindrop bookmarks
+#     """
+#     uri = RAINDROP_BOOKMARK_API.format(collection_id=collection_id)
+#     query_params = {'page': page_number, 'perpage': PAGE_SIZE}
+#     log.debug("Making request to %s", uri)
+#     response_data = requests.get(uri, params=query_params).json()
+#     items = response_data.get('items', [])
+#     total_item_count = response_data.get('count')
+#     log.debug("Retrieved %d of %d bookmarks", len(items), total_item_count)
+#     return items, total_item_count
 
 def build_parser() -> argparse.ArgumentParser:
     """Construct argument parser for script.
@@ -118,5 +123,5 @@ if __name__ == '__main__':
     if args.outfile:
         sys.stdout = open(args.outfile, 'w')
 
-    extract_bookmarks(args.collection)
+    write_bookmarks(args.collection)
     sys.exit(0)

--- a/extract-raindrop-bookmarks.py
+++ b/extract-raindrop-bookmarks.py
@@ -1,14 +1,15 @@
 """
 Script to retrieve all links from Raindrop Presterity collection.
 """
-
 import argparse
 import json
 import logging
 import sys
 from raindrop_api import extract_bookmarks
 
-DEFAUlT_PAGE_SIZE = 40
+log = logging.getLogger(__name__)
+
+DEFAULT_PAGE_SIZE = 40
 PRESTERITY_COLLECTION_ID = 2021037
 
 def build_parser() -> argparse.ArgumentParser:
@@ -22,8 +23,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument('--collection', '-c', type=int, default=PRESTERITY_COLLECTION_ID, 
                         help=help_msg)
     help_msg = 'number of requested bookmarks per query; default is {0} (max allowed)'.format(
-        DEFAUlT_PAGE_SIZE)
-    parser.add_argument('--page-size', '-s', type=int, default=DEFAUlT_PAGE_SIZE, help=help_msg)
+        DEFAULT_PAGE_SIZE)
+    parser.add_argument('--page-size', '-s', type=int, default=DEFAULT_PAGE_SIZE, help=help_msg)
     parser.add_argument('--outfile', '-o', help='file for results; default is stdout')
     parser.add_argument('--verbose', '-v', action='store_true', help='log level DEBUG')
     return parser
@@ -54,7 +55,6 @@ if __name__ == '__main__':
     args = build_parser().parse_args()
 #    log = init_logging(verbose=args.verbose, very_verbose=args.very_verbose)
     logging.basicConfig(level=logging.WARN)
-    log = logging.getLogger(__name__)
     if args.verbose:
         log.setLevel(logging.DEBUG)
     else:
@@ -64,7 +64,7 @@ if __name__ == '__main__':
     if args.outfile:
         sys.stdout = open(args.outfile, 'w')
 
-    collection_data = extract_bookmarks(args.collection, args.page_size, log)
+    collection_data = extract_bookmarks(args.collection, args.page_size)
     # Serialize data and write to stdout
     sys.stdout.write(json.dumps(collection_data, indent = 4))
 

--- a/extract-raindrop-bookmarks.py
+++ b/extract-raindrop-bookmarks.py
@@ -3,69 +3,13 @@ Script to retrieve all links from Raindrop Presterity collection.
 """
 
 import argparse
-from datetime import datetime
 import json
 import logging
 import sys
-from typing import List, Tuple
 from raindrop_api import extract_bookmarks
 
-import requests
-
-log = None
-
-RAINDROP_BOOKMARK_API = 'https://raindrop.io/api/raindrops/{collection_id}'
-PAGE_SIZE = 40  # max number of results per page 
+DEFAUlT_PAGE_SIZE = 40
 PRESTERITY_COLLECTION_ID = 2021037
-
-def write_bookmarks(collection_id: int) -> None:
-    collection_data = extract_bookmarks(collection_id, log)
-    # Serialize data and write to stdout
-    sys.stdout.write(json.dumps(collection_data, indent = 4))
-
-
-# def extract_bookmarks(collection_id: int) -> dict:
-#     """Retrieve all bookmarks in specified collection; write results as JSON to stdout.
-
-#     For documentation on bookmark JSON: https://raindrop.io/dev/docs#bookmarks
-    
-#     :param collection_id: int that is Raindrop collection id
-#     """
-#     page_number = 0
-#     bookmarks, collection_size = get_bookmarks_on_page(collection_id, page_number=page_number)
-#     bookmarks_retrieved = len(bookmarks)
-#     collection_data = {'collection_id': collection_id,
-#                        'request_date': datetime.utcnow().isoformat(),
-#                        'length': collection_size,
-#                        'items': bookmarks}
-
-#     while bookmarks_retrieved < collection_size:
-#         page_number += 1
-#         bookmarks, new_size = get_bookmarks_on_page(collection_id, page_number=page_number)
-#         if new_size != collection_size:
-#             raise ValueError("Collection changed size during extract; please re-run")
-#         bookmarks_retrieved += len(bookmarks)
-#         collection_data['items'].extend(bookmarks)
-
-#     return collection_data
-    
-
-# def get_bookmarks_on_page(collection_id: int, page_number: int=0 ) -> Tuple[List[dict], int]:
-#     """Retrieve collection bookmarks for specified page number.
-
-#     :param collection_id: int that is Raindrop collection id
-#     :param page_number: optional int that is page number; default is 0
-
-#     :return: list of JSON objects that are Raindrop bookmarks
-#     """
-#     uri = RAINDROP_BOOKMARK_API.format(collection_id=collection_id)
-#     query_params = {'page': page_number, 'perpage': PAGE_SIZE}
-#     log.debug("Making request to %s", uri)
-#     response_data = requests.get(uri, params=query_params).json()
-#     items = response_data.get('items', [])
-#     total_item_count = response_data.get('count')
-#     log.debug("Retrieved %d of %d bookmarks", len(items), total_item_count)
-#     return items, total_item_count
 
 def build_parser() -> argparse.ArgumentParser:
     """Construct argument parser for script.
@@ -78,8 +22,8 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument('--collection', '-c', type=int, default=PRESTERITY_COLLECTION_ID, 
                         help=help_msg)
     help_msg = 'number of requested bookmarks per query; default is {0} (max allowed)'.format(
-        PAGE_SIZE)
-    parser.add_argument('--page-size', '-s', type=int, default=PAGE_SIZE, help=help_msg)
+        DEFAUlT_PAGE_SIZE)
+    parser.add_argument('--page-size', '-s', type=int, default=DEFAUlT_PAGE_SIZE, help=help_msg)
     parser.add_argument('--outfile', '-o', help='file for results; default is stdout')
     parser.add_argument('--verbose', '-v', action='store_true', help='log level DEBUG')
     return parser
@@ -116,12 +60,12 @@ if __name__ == '__main__':
     else:
         log.setLevel(logging.INFO)
 
-    # Set module-level constant PAGE_SIZE
-    PAGE_SIZE = args.page_size
-
     # Redirect stdout to outfile, if specified
     if args.outfile:
         sys.stdout = open(args.outfile, 'w')
 
-    write_bookmarks(args.collection)
+    collection_data = extract_bookmarks(args.collection, args.page_size, log)
+    # Serialize data and write to stdout
+    sys.stdout.write(json.dumps(collection_data, indent = 4))
+
     sys.exit(0)

--- a/raindrop_api.py
+++ b/raindrop_api.py
@@ -1,0 +1,55 @@
+"""
+Module for accessing the raindrop.io API
+"""
+from datetime import datetime
+import json
+from typing import List, Tuple
+import requests
+
+
+RAINDROP_BOOKMARK_API = 'https://raindrop.io/api/raindrops/{collection_id}'
+PAGE_SIZE = 40  # max number of results per page 
+
+def extract_bookmarks(collection_id: int) -> dict:
+    """Retrieve all bookmarks in specified collection; write results as JSON to stdout.
+
+    For documentation on bookmark JSON: https://raindrop.io/dev/docs#bookmarks
+    
+    :param collection_id: int that is Raindrop collection id
+    """
+    page_number = 0
+    bookmarks, collection_size = get_bookmarks_on_page(collection_id, page_number=page_number)
+    bookmarks_retrieved = len(bookmarks)
+    collection_data = {'collection_id': collection_id,
+                       'request_date': datetime.utcnow().isoformat(),
+                       'length': collection_size,
+                       'items': bookmarks}
+
+    while bookmarks_retrieved < collection_size:
+        page_number += 1
+        bookmarks, new_size = get_bookmarks_on_page(collection_id, page_number=page_number)
+        if new_size != collection_size:
+            raise ValueError("Collection changed size during extract; please re-run")
+        bookmarks_retrieved += len(bookmarks)
+        collection_data['items'].extend(bookmarks)
+
+    return collection_data
+    
+def get_bookmarks_on_page(collection_id: int, page_number: int=0, log: object=None ) -> Tuple[List[dict], int]:
+    """Retrieve collection bookmarks for specified page number.
+
+    :param collection_id: int that is Raindrop collection id
+    :param page_number: optional int that is page number; default is 0
+
+    :return: list of JSON objects that are Raindrop bookmarks
+    """
+    uri = RAINDROP_BOOKMARK_API.format(collection_id=collection_id)
+    query_params = {'page': page_number, 'perpage': PAGE_SIZE}
+    if log is not None:
+    	log.debug("Making request to %s", uri)
+    response_data = requests.get(uri, params=query_params).json()
+    items = response_data.get('items', [])
+    total_item_count = response_data.get('count')
+    if log is not None:
+    	log.debug("Retrieved %d of %d bookmarks", len(items), total_item_count)
+    return items, total_item_count

--- a/raindrop_api.py
+++ b/raindrop_api.py
@@ -7,11 +7,12 @@ from typing import List, Tuple
 import requests
 import logging
 
+log = logging.getLogger(__name__)
 
 RAINDROP_BOOKMARK_API = 'https://raindrop.io/api/raindrops/{collection_id}'
 DEFAULT_PAGE_SIZE = 40  # max number of results per page 
 
-def extract_bookmarks(collection_id: int, page_size: int=DEFAULT_PAGE_SIZE, log: logging.Logger=None) -> dict:
+def extract_bookmarks(collection_id: int, page_size: int=DEFAULT_PAGE_SIZE) -> dict:
     """Retrieve all bookmarks in specified collection; write results as JSON to stdout.
 
     For documentation on bookmark JSON: https://raindrop.io/dev/docs#bookmarks
@@ -19,7 +20,7 @@ def extract_bookmarks(collection_id: int, page_size: int=DEFAULT_PAGE_SIZE, log:
     :param collection_id: int that is Raindrop collection id
     """
     page_number = 0
-    bookmarks, collection_size = get_bookmarks_on_page(collection_id, page_number, page_size, log)
+    bookmarks, collection_size = get_bookmarks_on_page(collection_id, page_number, page_size)
     bookmarks_retrieved = len(bookmarks)
     collection_data = {'collection_id': collection_id,
                        'request_date': datetime.utcnow().isoformat(),
@@ -28,7 +29,7 @@ def extract_bookmarks(collection_id: int, page_size: int=DEFAULT_PAGE_SIZE, log:
 
     while bookmarks_retrieved < collection_size:
         page_number += 1
-        bookmarks, new_size = get_bookmarks_on_page(collection_id, page_number, page_size, log)
+        bookmarks, new_size = get_bookmarks_on_page(collection_id, page_number, page_size)
         if new_size != collection_size:
             raise ValueError("Collection changed size during extract; please re-run")
         bookmarks_retrieved += len(bookmarks)
@@ -36,7 +37,7 @@ def extract_bookmarks(collection_id: int, page_size: int=DEFAULT_PAGE_SIZE, log:
 
     return collection_data
     
-def get_bookmarks_on_page(collection_id: int, page_number: int=0, page_size: int=DEFAULT_PAGE_SIZE, log: logging.Logger=None) -> Tuple[List[dict], int]:
+def get_bookmarks_on_page(collection_id: int, page_number: int=0, page_size: int=DEFAULT_PAGE_SIZE) -> Tuple[List[dict], int]:
     """Retrieve collection bookmarks for specified page number.
 
     :param collection_id: int that is Raindrop collection id
@@ -46,11 +47,9 @@ def get_bookmarks_on_page(collection_id: int, page_number: int=0, page_size: int
     """
     uri = RAINDROP_BOOKMARK_API.format(collection_id=collection_id)
     query_params = {'page': page_number, 'perpage': page_size}
-    if log is not None:
-    	log.debug("Making request to %s", uri)
+    log.debug("Making request to %s", uri)
     response_data = requests.get(uri, params=query_params).json()
     items = response_data.get('items', [])
     total_item_count = response_data.get('count')
-    if log is not None:
-    	log.debug("Retrieved %d of %d bookmarks", len(items), total_item_count)
+    log.debug("Retrieved %d of %d bookmarks", len(items), total_item_count)
     return items, total_item_count

--- a/wayback_api.py
+++ b/wayback_api.py
@@ -9,21 +9,41 @@ SAVE_PAGE_API  = 'http://web.archive.org/save/{url}'
 # see: https://archive.org/help/wayback_api.php
 CHECK_PAGE_API = 'http://archive.org/wayback/available'
 
+def check_url(url: str) -> str:
+	"""
+	Check that a URL is archived
+
+	:param url: the URL to check
+	:return: the archived URL, or None if not archived
+	"""
+	response_data = requests.get(CHECK_PAGE_API, params={'url': url}).json()
+	return response_data.get('archived_snapshots', {}).get('closest', {}).get('url', None)
+
+
 def archive_url(url: str) -> str:
 	"""
-	Check that a URL is archived. If it isn't already, archive it and return the archive URL.
-	"""
-	print("archiving url ", url)
-	response_data = requests.get(CHECK_PAGE_API, params={'url': url}).json()
-	archived_url = response_data.get('archived_snapshots', {}).get('closest', {}).get('url', None)
-	if archived_url is None:
-		# 1. go add it
-		save_url = SAVE_PAGE_API.format(url=url)
-		response = requests.get(save_url)
-		# throw exception if response was not 200 OK
-		response.raise_for_status() 
-		# 2. look it up again
-		return archive_url(url) # TODO: limit retries
-	else:
-		return archived_url
+	Archive a URL
 
+	:param url: the URL to archive
+	:return: the newly archived URL, or None if there was a problem archiving it
+	"""
+	save_url = SAVE_PAGE_API.format(url=url)
+	response = requests.get(save_url)
+
+	if response.status_code is not 200:
+		return None # TODO: return the error to be handled later
+
+	return check_url(url)
+
+def check_and_archive_url(url: str) -> str:
+	"""
+	Check to see if a URL is archived. If it is, return the archived URL. If it isn't, archive it and then return the archived URL.
+
+	:param url: the URL to check (and archive if not already)
+	:return: the URL that has been archived, or None if there was a problem archiving it
+	"""
+	archived = check_url(url)
+	if archived is None:
+		return archive_url(url)
+	else:
+		return archived

--- a/wayback_api.py
+++ b/wayback_api.py
@@ -1,0 +1,29 @@
+"""
+Module for accessing the web archive wayback machine (https://archive.org/web/)
+"""
+from typing import List, Tuple
+import requests
+
+# undocumented API scraped from the 'save page' form here: https://archive.org/web/
+SAVE_PAGE_API  = 'http://web.archive.org/save/{url}'
+# see: https://archive.org/help/wayback_api.php
+CHECK_PAGE_API = 'http://archive.org/wayback/available'
+
+def archive_url(url: str) -> str:
+	"""
+	Check that a URL is archived. If it isn't already, archive it and return the archive URL.
+	"""
+	print("archiving url ", url)
+	response_data = requests.get(CHECK_PAGE_API, params={'url': url}).json()
+	archived_url = response_data.get('archived_snapshots', {}).get('closest', {}).get('url', None)
+	if archived_url is None:
+		# 1. go add it
+		save_url = SAVE_PAGE_API.format(url=url)
+		response = requests.get(save_url)
+		# throw exception if response was not 200 OK
+		response.raise_for_status() 
+		# 2. look it up again
+		return archive_url(url) # TODO: limit retries
+	else:
+		return archived_url
+

--- a/wayback_api.py
+++ b/wayback_api.py
@@ -10,40 +10,40 @@ SAVE_PAGE_API  = 'http://web.archive.org/save/{url}'
 CHECK_PAGE_API = 'http://archive.org/wayback/available'
 
 def check_url(url: str) -> str:
-	"""
-	Check that a URL is archived
+    """
+    Check that a URL is archived
 
-	:param url: the URL to check
-	:return: the archived URL, or None if not archived
-	"""
-	response_data = requests.get(CHECK_PAGE_API, params={'url': url}).json()
-	return response_data.get('archived_snapshots', {}).get('closest', {}).get('url', None)
+    :param url: the URL to check
+    :return: the archived URL, or None if not archived
+    """
+    response_data = requests.get(CHECK_PAGE_API, params={'url': url}).json()
+    return response_data.get('archived_snapshots', {}).get('closest', {}).get('url', None)
 
 
 def archive_url(url: str) -> str:
-	"""
-	Archive a URL
+    """
+    Archive a URL
 
-	:param url: the URL to archive
-	:return: the newly archived URL, or None if there was a problem archiving it
-	"""
-	save_url = SAVE_PAGE_API.format(url=url)
-	response = requests.get(save_url)
+    :param url: the URL to archive
+    :return: the newly archived URL, or None if there was a problem archiving it
+    """
+    save_url = SAVE_PAGE_API.format(url=url)
+    response = requests.get(save_url)
 
-	if response.status_code is not 200:
-		return None # TODO: return the error to be handled later
+    if response.status_code is not 200:
+        return None # TODO: return the error to be handled later
 
-	return check_url(url)
+    return check_url(url)
 
 def check_and_archive_url(url: str) -> str:
-	"""
-	Check to see if a URL is archived. If it is, return the archived URL. If it isn't, archive it and then return the archived URL.
+    """
+    Check to see if a URL is archived. If it is, return the archived URL. If it isn't, archive it and then return the archived URL.
 
-	:param url: the URL to check (and archive if not already)
-	:return: the URL that has been archived, or None if there was a problem archiving it
-	"""
-	archived = check_url(url)
-	if archived is None:
-		return archive_url(url)
-	else:
-		return archived
+    :param url: the URL to check (and archive if not already)
+    :return: the URL that has been archived, or None if there was a problem archiving it
+    """
+    archived = check_url(url)
+    if archived is None:
+        return archive_url(url)
+    else:
+        return archived


### PR DESCRIPTION
creating batch script that makes sure that raindrop bookmarks are included in the wayback machine (web archive)
    - archive-links.py is the main command-line script that does the archiving
    - raindrop_api.py contains general-purpose APIs for accessing raindrop (extracted from extract-raindrop-bookmarks.py)
    - extract-raindrop-bookmarks.py - refactored to use the above module
    - wayback_api.py - general purpose API for accessing the web archive

TODO:
    - seems to have problems with URLs that have query params (at least this example doesn't work: https://www.nytimes.com/2017/02/17/opinion/a-party-to-the-russian-connection.html?smid=tw-share)
    - make the requests async (should be faster)
